### PR TITLE
Initial prototype for syncing the github template repo between orgs

### DIFF
--- a/.github/workflows/propogate_templates.yml
+++ b/.github/workflows/propogate_templates.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:
 
 env:
   ORGS: menes-dotnet,corvus-dotnet

--- a/.github/workflows/propogate_templates.yml
+++ b/.github/workflows/propogate_templates.yml
@@ -1,0 +1,25 @@
+name: propogate_templates
+on: 
+  push:
+    branches:
+    - master
+
+env:
+  ORGS: menes-dotnet,corvus-dotnet
+
+jobs:
+  sync_templates_to_orgs:
+    # only run in the source organisation
+    if: |
+      github.repository_owner == 'endjin'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        depth: 0
+    - run: |
+        $orgs = "${{ env.ORGS -split ',' }}"
+        ./sync-repo-to-orgs.ps1 -Organisations $orgs
+      shell: pwsh
+      env:
+        SSH_PRIVATE_KEY: ${{ secrets.ENDJIN_BOT_PRIVATE_KEY }}

--- a/sync-repo-to-orgs.ps1
+++ b/sync-repo-to-orgs.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param (
     [Parameter(Mandatory=$true)]
     [string[]]
@@ -14,16 +14,21 @@ try {
         $repoUrl = "git@github.com:{0}/.github.git" -f $org
 
         Write-Host "`nProcessing: $repoUrl"
-        git remote add target $repoUrl
-        if ($LASTEXITCODE -ne 0) { throw "Error configuring remote for '$org' - check logs" }
+        if ($PSCmdlet.ShouldProcess($Organisations)) {
+            git remote add target $repoUrl
+            if ($LASTEXITCODE -ne 0) { throw "Error configuring remote for '$org' - check logs" }
 
-        try {
-            Write-Host " --> Syncing"
-            git push -f target master
-            if ($LASTEXITCODE -ne 0) { throw "Error pushing to remote for '$org' - check logs" }
+            try {
+                Write-Host " --> Syncing"
+                git push -f target master
+                if ($LASTEXITCODE -ne 0) { throw "Error pushing to remote for '$org' - check logs" }
+            }
+            finally {
+                git remote remove target
+            }
         }
-        finally {
-            git remote remove target
+        else {
+            Write-Host " --> Would have synced"
         }
     }
 }

--- a/sync-repo-to-orgs.ps1
+++ b/sync-repo-to-orgs.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
+    $Organisations
+)
+$ErrorActionPreference = 'Stop'
+
+try {
+    Write-Host ("Organisations to sync:`n - {0}" -f ($Organisations -join "`n - "))
+    Write-Host ("Commit to sync:`n{0}" -f $(& git --no-pager branch -v))
+
+    foreach ($org in $Organisations) {
+        $repoUrl = "git@github.com:{0}/.github.git" -f $org
+
+        Write-Host "`nProcessing: $repoUrl"
+        git remote add target $repoUrl
+        if ($LASTEXITCODE -ne 0) { throw "Error configuring remote for '$org' - check logs" }
+
+        try {
+            Write-Host " --> Syncing"
+            git push -f target master
+            if ($LASTEXITCODE -ne 0) { throw "Error pushing to remote for '$org' - check logs" }
+        }
+        finally {
+            git remote remove target
+        }
+    }
+}
+catch {
+    Write-Error $_.Exception.Message
+    Write-Output ("::error file={0},line={1},col={2}::{3}" -f `
+                        $_.InvocationInfo.ScriptName,
+                        $_.InvocationInfo.ScriptLineNumber,
+                        $_.InvocationInfo.OffsetInLine,
+                        $_.Exception.Message)
+    exit 1
+}


### PR DESCRIPTION
The `.github` repo in the `endjin` organisation would be the source of the truth and any commits to `master` would be force pushed to the `master` branch of each configured organisation.

Pre-Reqs for each target org:
- `.github` repo already exists
-  no `master` branch protection
