### PR TITLE
Add new workflows for packaging & releasing Endjin.CodeOps module

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -1,0 +1,160 @@
+name: auto_release
+on: 
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  check_for_norelease_label:
+    runs-on: ubuntu-latest
+    outputs:
+      no_release: ${{ steps.check_for_norelease_label.outputs.result }}
+    steps:
+    - name: Check for 'no_release' label on PR
+      id: check_for_norelease_label
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+            const labels = await github.issues.listLabelsOnIssue({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: context.payload.number
+            });
+            core.info("labels: " + JSON.stringify(labels.data))
+            if ( labels.data.map(l => l.name).includes("no_release") ) {
+              core.info("Label found")
+              return true
+            }
+            return false
+    - name: Display 'no_release' status
+      run: |
+        echo "no_release: ${{ steps.check_for_norelease_label.outputs.result }}"
+
+  check_ready_to_release:
+    runs-on: ubuntu-latest
+    needs: check_for_norelease_label
+    if: |
+      needs.check_for_norelease_label.outputs.no_release == 'false'
+    outputs:
+      no_open_prs: ${{ steps.watch_dependabot_prs.outputs.is_complete }}
+      pending_release_pr_list: ${{ steps.get_release_pending_pr_list.outputs.result }}
+      ready_to_release: ${{ steps.watch_dependabot_prs.outputs.is_complete == 'True' && steps.get_release_pending_pr_list.outputs.is_release_pending }}
+    steps:
+    - name: Get Open PRs
+      id: get_open_pr_list
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const pulls = await github.pulls.list({
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name,
+            state: 'open',
+            base: 'master'
+          });
+          return JSON.stringify(pulls.data.map(p=>p.title))
+        result-encoding: string
+    - name: Display open_pr_list
+      run: |
+        echo "open_pr_list : ${{ steps.get_open_pr_list.outputs.result }}"
+
+    - name: Get 'pending_release' PRs
+      id: get_release_pending_pr_list
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const pulls = await github.search.issuesAndPullRequests({
+            q: 'is:pr is:merged label:pending_release',
+          });
+          core.info(`pulls: ${pulls.data.items}`)
+          const repoUrl = `https://api.github.com/repos/${context.payload.repository.owner.login}/${context.payload.repository.name}`
+          const release_pending_prs = pulls.data.items.
+                                        filter(function (x) { return x.repository_url == repoUrl; }).
+                                        map(p=>p.number);
+          core.info(`release_pending_prs: ${release_pending_prs}`)
+          core.setOutput('is_release_pending', (release_pending_prs.length > 0))
+          return JSON.stringify(release_pending_prs)
+        result-encoding: string
+    - name: Display release_pending_pr_list
+      run: |
+        echo "release_pending_pr_list : ${{ steps.get_release_pending_pr_list.outputs.result }}"
+        echo "is_release_pending : ${{ steps.get_release_pending_pr_list.outputs.is_release_pending }}"
+
+    - uses: actions/checkout@v2
+    - name: Read pr-autoflow configuration
+      id: get_pr_autoflow_config
+      uses: endjin/pr-autoflow/actions/read-configuration@v1
+      with:
+        config_file: .github/config/pr-autoflow.json
+
+    - name: Watch Dependabot PRs
+      id: watch_dependabot_prs      
+      uses: endjin/pr-autoflow/actions/dependabot-pr-watcher@v1
+      with:
+        pr_titles: ${{ steps.get_open_pr_list.outputs.result }}
+        package_wildcard_expressions: ${{ steps.get_pr_autoflow_config.outputs.AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS }}
+        max_semver_increment: minor
+        verbose_mode: 'False'
+
+    - name: Display job outputs
+      run: |
+        echo "no_open_prs: ${{ steps.watch_dependabot_prs.outputs.is_complete }}"
+        echo "pending_release_pr_list: ${{ steps.get_release_pending_pr_list.outputs.result }}"
+        echo "ready_to_release : ${{ steps.watch_dependabot_prs.outputs.is_complete == 'True' && steps.get_release_pending_pr_list.outputs.is_release_pending }}"
+
+  tag_for_release:
+    runs-on: ubuntu-latest
+    needs: check_ready_to_release
+    if: |
+      needs.check_ready_to_release.outputs.ready_to_release == 'true'
+    steps:
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install GitVersion
+      run: |
+        dotnet tool install -g GitVersion.Tool --version 5.2.4
+        echo "::add-path::/github/home/.dotnet/tools"    
+    - name: Run GitVersion
+      id: run_gitversion
+      run: |
+        pwsh -noprofile -c '(dotnet-gitversion | ConvertFrom-Json).psobject.properties | % { echo ("::set-output name={0}::{1}" -f $_.name, $_.value) }'
+
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.ENDJIN_BOT_APP_ID }}
+        private_key: ${{ secrets.ENDJIN_BOT_PRIVATE_KEY }}
+
+    - name: Create SemVer tag
+      uses: hole19/git-tag-action@master
+      env:
+        TAG: ${{ steps.run_gitversion.outputs.MajorMinorPatch }}
+        GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
+
+    - name: Remove 'release_pending' label from PRs
+      id: remove_pending_release_labels
+      uses: actions/github-script@v2
+      with:
+        github-token: '${{ steps.generate_token.outputs.token }}'
+        script: |
+          core.info('PRs to unlabel: ${{ needs.check_ready_to_release.outputs.pending_release_pr_list }}')
+          const pr_list = JSON.parse('${{ needs.check_ready_to_release.outputs.pending_release_pr_list }}')
+          core.info(`pr_list: ${pr_list}`)
+          for (const i of pr_list) {
+            core.info(`Removing label 'pending_release' from issue #${i}`)
+            github.issues.removeLabel({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: i,
+              name: 'pending_release'
+            });
+          }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+on:
+- push
+- workflow_dispatch
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    name: Run Pester tests
+    steps:
+    - uses: actions/checkout@v2
+    - run: pwsh -f ./run-tests.ps1
+
+  run_gitversion:
+    runs-on: ubuntu-latest
+    name: Run GitVersion
+    outputs:
+      semver: ${{ steps.gitversion.outputs.semver }}
+      preReleaseTag: ${{ steps.gitversion.outputs.preReleaseTag }}
+    steps:
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install GitVersion
+      run: |
+        dotnet tool install -g GitVersion.Tool --version 5.2.4
+        echo "::add-path::/github/home/.dotnet/tools"    
+        
+    - name: Run GitVersion
+      id: run_gitversion
+      run: |
+        pwsh -noprofile -c '(dotnet-gitversion | ConvertFrom-Json).psobject.properties | % { echo ("::set-output name={0}::{1}" -f $_.name, $_.value) }'
+

--- a/.github/workflows/publish_to_psgallery.yml
+++ b/.github/workflows/publish_to_psgallery.yml
@@ -1,0 +1,61 @@
+name: publish_to_psgallery
+on:
+- push
+- workflow_dispatch
+
+jobs:
+  run_gitversion:
+    runs-on: ubuntu-latest
+    name: Run GitVersion
+    # only trigger for pushed tags
+    if: |
+      startsWith(github.event.ref, 'refs/tags/')
+    outputs:
+      majorMinorPatch: ${{ steps.run_gitversion.outputs.MajorMinorPatch }}
+      nuGetPreReleaseTag: ${{ steps.run_gitversion.outputs.NuGetPreReleaseTag }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Install GitVersion
+      run: |
+        dotnet tool install -g GitVersion.Tool --version 5.2.4
+        echo "::add-path::/github/home/.dotnet/tools"    
+    - name: Run GitVersion
+      id: run_gitversion
+      run: |
+        pwsh -noprofile -c '(dotnet-gitversion | ConvertFrom-Json).psobject.properties | % { echo ("::set-output name={0}::{1}" -f $_.name, $_.value) }'
+
+  publish_to_psgallery:
+    runs-on: ubuntu-latest
+    name: Publish to PowerShell Gallery
+    needs: run_gitversion
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Read workflow configuration
+      id: get_config
+      uses: endjin/pr-autoflow/actions/read-configuration@v1
+      with:
+        config_file: .workflow-config.json
+  
+    - run: |
+        # Ensure any required modules are installed
+        $manifest = Get-Content -Raw ${{ steps.get_config.outputs.module_manifest_path }} | Invoke-Expression
+        $manifest.RequiredModules | Where-Object { $_ } | ForEach-Object { Install-Module -Name $_ -Scope CurrentUser -Force }
+
+        Update-ModuleManifest -Path ${{ steps.get_config.outputs.module_manifest_path }} `
+                              -ModuleVersion ${{ needs.run_gitversion.outputs.majorMinorPatch }} `
+                              -Prerelease "${{ needs.run_gitversion.outputs.nuGetPreReleaseTag }}" `
+                              -FunctionsToExport @("*") `
+                              -CmdletsToExport @() `
+                              -AliasesToExport @()
+        Publish-Module -Name ${{ steps.get_config.outputs.module_manifest_path }} `
+                              -NuGetApiKey ${{ secrets.ENDJIN_PSGALLERY_APIKEY }} `
+                              -AllowPrerelease `
+                              -Verbose
+      shell: pwsh
+      name: Publish module


### PR DESCRIPTION
Workflows without a 'push' trigger need to hit `master` before they are visible in the UI for testing