### PR TITLE
Extend 'Get-Repos' functionality to support reading from a remote repo

### DIFF
--- a/.github/config/pr-autoflow.json
+++ b/.github/config/pr-autoflow.json
@@ -1,5 +1,0 @@
-{
-    "AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS": "[\"Endjin.*\", \"Corvus.*\"]",
-    "AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS": "[]",
-    "module_manifest_path": "./Endjin.CodeOps/Endjin.CodeOps.psd1"
-}

--- a/.github/config/ps-module.json
+++ b/.github/config/ps-module.json
@@ -1,0 +1,3 @@
+{
+    "module_manifest_path": "./Endjin.CodeOps/Endjin.CodeOps.psd1"
+}

--- a/.github/workflows/deploy_pr_autoflow.yml
+++ b/.github/workflows/deploy_pr_autoflow.yml
@@ -28,7 +28,10 @@ jobs:
           $credentialHelperPath = Resolve-Path ./git-credential-helper.sh
           git config --global credential.helper "/bin/bash $($credentialHelperPath.Path)"
           
-          .\sync-pr-autoflow-to-repos.ps1 -ConfigDirectory "repos/test"
+          .\sync-pr-autoflow-to-repos.ps1 -ConfigDirectory "repos/test" `
+                                          -AddOverwriteSettings `
+                                          -ConfigureGitVersion `
+                                          -ConfigureDependabotV2
         shell: pwsh
         env:
           SSH_PRIVATE_KEY: ${{ secrets.DEPENDJINBOT_PRIVATE_KEY }}

--- a/.github/workflows/publish_to_psgallery.yml
+++ b/.github/workflows/publish_to_psgallery.yml
@@ -40,7 +40,7 @@ jobs:
       id: get_config
       uses: endjin/pr-autoflow/actions/read-configuration@v1
       with:
-        config_file: .github/config/pr-autoflow.json
+        config_file: .github/config/ps-module.json
   
     - run: |
         # Ensure any required modules are installed

--- a/Endjin.CodeOps/functions/Update-Repo.ps1
+++ b/Endjin.CodeOps/functions/Update-Repo.ps1
@@ -42,9 +42,20 @@ function Update-Repo {
         git clone $RepoUrl .
         if ($LASTEXITCODE -ne 0) { throw "git cli returned non-zero exit code cloning the repo - check previous log messages" }
 
-        Write-Host "Creating new branch: $BranchName"
-        git checkout -b $BranchName
-        if ($LASTEXITCODE -ne 0) { throw "git cli returned non-zero exit code checking out new branch - check previous log messages" }
+        # Check whether the branch already exists on the remote
+        if ( $(git ls-remote --heads $RepoUrl $BranchName) ) {
+            Write-Host "Checking-out existing branch: $BranchName"
+            git checkout $BranchName
+            if ($LASTEXITCODE -ne 0) { throw "git cli returned non-zero exit code checking out existing branch - check previous log messages" }
+            Write-Host "Syncing branch with master"
+            git merge master
+            if ($LASTEXITCODE -ne 0) { throw "git cli returned non-zero exit code rebasing against master - check previous log messages" }
+        }
+        else {
+            Write-Host "Creating new branch: $BranchName"
+            git checkout -b $BranchName
+            if ($LASTEXITCODE -ne 0) { throw "git cli returned non-zero exit code checking out new branch - check previous log messages" }
+        }
 
         $isUpdated = $RepoChanges.Invoke()
 

--- a/Endjin.CodeOps/functions/Update-Repo.ps1
+++ b/Endjin.CodeOps/functions/Update-Repo.ps1
@@ -25,13 +25,15 @@ function Update-Repo {
         $env:GITHUB_TOKEN = $ghConfig."github.com".oauth_token
     }
 
-    Write-Host "Checking for 'no_release' label"
-    $resp = Ensure-GitHubLabel -OrgName $OrgName `
-                               -RepoName $RepoName `
-                               -Name 'no_release' `
-                               -Description 'Suppresses auto_release functionality' `
-                               -Color '27e8b4' `
-                               -Verbose:$False
+    if ('no_release' -in $PrLabels) {
+        Write-Host "Checking for 'no_release' label"
+        $resp = Ensure-GitHubLabel -OrgName $OrgName `
+                                -RepoName $RepoName `
+                                -Name 'no_release' `
+                                -Description 'Suppresses auto_release functionality' `
+                                -Color '27e8b4' `
+                                -Verbose:$False
+    }
 
     $tempDir = New-TemporaryDirectory
     Push-Location $tempDir.FullName

--- a/migrate-to-specflow-meta-package.ps1
+++ b/migrate-to-specflow-meta-package.ps1
@@ -29,7 +29,8 @@ $requiredModules = @(
 $requiredModules | ForEach-Object {
     if ( !(Get-Module -ListAvailable $_) ) {
         Install-Module $_ -Scope CurrentUser -Repository PSGallery -Force
-    }   
+    }
+    Import-Module $_
 }
 
 # The list of NuGet packages that are superceded/replaced by the single meta-package

--- a/migrate-to-specflow-meta-package.ps1
+++ b/migrate-to-specflow-meta-package.ps1
@@ -36,6 +36,7 @@ $requiredModules | ForEach-Object {
 $supercededPackages = @(
             'SpecFlow'
             'SpecFlow.NUnit'
+            'SpecFlow.NUnit.Runners'
             'SpecFlow.Tools.MsBuild.Generation'
             'coverlet.msbuild'
             'Microsoft.NET.Test.Sdk'

--- a/migrate-to-specflow-meta-package.ps1
+++ b/migrate-to-specflow-meta-package.ps1
@@ -107,7 +107,7 @@ function _repoChanges
 function _main
 {
     try {
-        $repos = Get-AllRepoConfiguration -ConfigDirectory $ConfigDirectory
+        $repos = Get-AllRepoConfiguration -ConfigDirectory $ConfigDirectory -LocalMode
         foreach ($repo in $repos) {
             # When running in GitHub Actions we will need ensure the GitHub App is
             # authenticated for the current GitHub Org

--- a/repos/live/ais-dotnet.yml
+++ b/repos/live/ais-dotnet.yml
@@ -4,6 +4,8 @@ repos:
     - Ais.Net
     - Ais.Net.Receiver
     - Ais.Net.Converters
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*

--- a/repos/live/corvus-dotnet.yml
+++ b/repos/live/corvus-dotnet.yml
@@ -14,6 +14,8 @@ repos:
     - Corvus.EventStore
     - Corvus.DotLiquidAsync
     - Corvus.Tenancy
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
@@ -27,6 +29,8 @@ repos:
   # Corvus.Testing auto-merges changes to SpecFlow packages
   - org: corvus-dotnet
     name: Corvus.Testing
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*

--- a/repos/live/marain-dotnet.yml
+++ b/repos/live/marain-dotnet.yml
@@ -9,6 +9,8 @@ repos:
     - Marain.UserNotifications
     - Marain.KeyRotation
     - Marain.Tenancy
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*

--- a/repos/live/menes-dotnet.yml
+++ b/repos/live/menes-dotnet.yml
@@ -2,6 +2,8 @@ repos:
   - org: menes-dotnet
     name:
     - Menes
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*

--- a/repos/live/vellum-dotnet.yml
+++ b/repos/live/vellum-dotnet.yml
@@ -6,8 +6,7 @@ repos:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
       - Corvus.*
-      AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS:
-      - Corvus.*
+      AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: []
     specflowMetaPackageSettings:
       enabled: true
     syncWorkflowTemplates: true

--- a/repos/live/vellum-dotnet.yml
+++ b/repos/live/vellum-dotnet.yml
@@ -2,6 +2,8 @@ repos:
   - org: vellum-dotnet
     name:
     - vellum-cli
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*

--- a/repos/test/playground.yml
+++ b/repos/test/playground.yml
@@ -5,8 +5,10 @@ repos:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS:
       - Endjin.*
       - Corvus.*
+      - dependency-playground-lib
       AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS:
       - Corvus.*
+      - dependency-playground-lib
     specflowMetaPackageSettings:
       enabled: true
     syncWorkflowTemplates: false

--- a/repos/test/playground.yml
+++ b/repos/test/playground.yml
@@ -19,6 +19,8 @@ repos:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
       - Corvus.*
+      AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS:
+      - Corvus.*
     specflowMetaPackageSettings:
       enabled: true
   - org: vellum-dotnet
@@ -28,6 +30,7 @@ repos:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
       - Corvus.*
+    AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: []
     specflowMetaPackageSettings:
       enabled: true
     syncWorkflowTemplates: true

--- a/repos/test/playground.yml
+++ b/repos/test/playground.yml
@@ -2,7 +2,7 @@ repos:
   - org: endjin
     name: dependency-playground
     githubSettings:
-      delete_branch_on_merge: false
+      delete_branch_on_merge: true
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS:
       - Endjin.*
@@ -18,7 +18,7 @@ repos:
     name:
     - Corvus.Retry
     githubSettings:
-      delete_branch_on_merge: false
+      delete_branch_on_merge: true
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
@@ -31,7 +31,7 @@ repos:
     name:
     - vellum-cli
     githubSettings:
-      delete_branch_on_merge: false
+      delete_branch_on_merge: true
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*

--- a/repos/test/playground.yml
+++ b/repos/test/playground.yml
@@ -1,6 +1,8 @@
 repos:
   - org: endjin
     name: dependency-playground
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS:
       - Endjin.*
@@ -15,6 +17,8 @@ repos:
   - org: corvus-dotnet
     name:
     - Corvus.Retry
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
@@ -26,6 +30,8 @@ repos:
   - org: vellum-dotnet
     name:
     - vellum-cli
+    githubSettings:
+      delete_branch_on_merge: false
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*

--- a/sync-pr-autoflow-to-repos.ps1
+++ b/sync-pr-autoflow-to-repos.ps1
@@ -17,7 +17,7 @@ $modulePath = Join-Path $here 'Endjin.CodeOps/Endjin.CodeOps.psd1'
 Get-Module Endjin.CodeOps | Remove-Module -Force
 Import-Module $modulePath
 
-$repos = Get-AllRepoConfiguration $ConfigDirectory
+$repos = Get-AllRepoConfiguration -ConfigDirectory $ConfigDirectory -LocalMode
 
 Write-Host "Repo count: " $repos.Count
 

--- a/sync-pr-autoflow-to-repos.ps1
+++ b/sync-pr-autoflow-to-repos.ps1
@@ -39,6 +39,11 @@ $repos | ForEach-Object {
     foreach ($repoName in $repo.name) {
         Write-Host "`nOrg: $($repo.org) - Repo: $($repoName)`n" -f green
 
+        Write-Host "Enabling 'delete_branch_on_merge' repo setting"
+        $resp = Invoke-GitHubRestRequest -Url "https://api.github.com/repos/$($repo.org)/$repoName" `
+                                         -Verb 'PATCH' `
+                                         -Body (@{delete_branch_on_merge=$true} | ConvertTo-Json -Compress)
+
         $repoChanges = {
             Write-Host "Adding/overwriting workflow files"
             $workflowsFolder = ".github/workflows"

--- a/sync-pr-autoflow-to-repos.ps1
+++ b/sync-pr-autoflow-to-repos.ps1
@@ -39,10 +39,12 @@ $repos | ForEach-Object {
     foreach ($repoName in $repo.name) {
         Write-Host "`nOrg: $($repo.org) - Repo: $($repoName)`n" -f green
 
-        Write-Host "Enabling 'delete_branch_on_merge' repo setting"
-        $resp = Invoke-GitHubRestRequest -Url "https://api.github.com/repos/$($repo.org)/$repoName" `
-                                         -Verb 'PATCH' `
-                                         -Body (@{delete_branch_on_merge=$true} | ConvertTo-Json -Compress)
+        if ($repo.githubSettings.delete_branch_on_merge -eq $true) {
+            Write-Host "Enabling 'delete_branch_on_merge' repo setting"
+            $resp = Invoke-GitHubRestRequest -Url "https://api.github.com/repos/$($repo.org)/$repoName" `
+                                            -Verb 'PATCH' `
+                                            -Body (@{delete_branch_on_merge=$true} | ConvertTo-Json -Compress)
+        }
 
         $repoChanges = {
             Write-Host "Adding/overwriting workflow files"

--- a/sync-pr-autoflow-to-repos.ps1
+++ b/sync-pr-autoflow-to-repos.ps1
@@ -68,7 +68,8 @@ $repos | ForEach-Object {
                     $settings[$_] = @(,$repo.prAutoflowSettings[$_]) | ConvertTo-Json -Compress
                 }
 
-                ConvertTo-Json $settings | Out-File (New-Item ".github/config/pr-autoflow.json" -Force)
+                # To avoid un-necessary changes (due to the non-deterministic ordering in hashtables) ensure the keys are sorted before serialization
+                $settings | Sort-Object -Property Name | ConvertTo-Json | Out-File (New-Item ".github/config/pr-autoflow.json" -Force)
             }
 
             if ($ConfigureGitVersion) {

--- a/sync-workflow-templates.ps1
+++ b/sync-workflow-templates.ps1
@@ -39,18 +39,18 @@ function _main
         $repoName = '.github'
         $repos = Get-AllRepoConfiguration -ConfigDirectory $ConfigDirectory -LocalMode
         foreach ($repo in $repos) {
-            # When running in GitHub Actions we will need to ensure the GitHub App is
-            # authenticated for the current GitHub Org
-            if ($env:SSH_PRIVATE_KEY -and $env:GITHUB_APP_ID) {
-                Write-Host "Getting access token for organisation: '$($repo.org)'"
-                $accessToken = New-GitHubAppInstallationAccessToken -AppId $env:GITHUB_APP_ID `
-                                                                    -AppPrivateKey $env:SSH_PRIVATE_KEY `
-                                                                    -OrgName $repo.org
-                # gh cli authentcation uses this environment variable
-                $env:GITHUB_TOKEN = $accessToken
-            }
+            if ($repo.syncWorkflowTemplates -eq $true) {
+                # When running in GitHub Actions we will need to ensure the GitHub App is
+                # authenticated for the current GitHub Org
+                if ($env:SSH_PRIVATE_KEY -and $env:GITHUB_APP_ID) {
+                    Write-Host "Getting access token for organisation: '$($repo.org)'"
+                    $accessToken = New-GitHubAppInstallationAccessToken -AppId $env:GITHUB_APP_ID `
+                                                                        -AppPrivateKey $env:SSH_PRIVATE_KEY `
+                                                                        -OrgName $repo.org
+                    # gh cli authentcation uses this environment variable
+                    $env:GITHUB_TOKEN = $accessToken
+                }
 
-            if ($repo.syncWorkflowTemplates) {
                 Write-Host ("`nProcessing Org: {0}" -f $repo.org) -f green
 
                 Update-Repo `
@@ -62,6 +62,9 @@ function _main
                     -PrTitle $PrTitle `
                     -PrBody $PrBody `
                     -WhatIf:$WhatIf
+            }
+            else {
+                Write-Host ("`nSkipping Org: {0}" -f $repo.org) -f green
             }
         }
     }

--- a/sync-workflow-templates.ps1
+++ b/sync-workflow-templates.ps1
@@ -37,7 +37,7 @@ function _main
 {
     try {
         $repoName = '.github'
-        $repos = Get-AllRepoConfiguration -ConfigDirectory $ConfigDirectory
+        $repos = Get-AllRepoConfiguration -ConfigDirectory $ConfigDirectory -LocalMode
         foreach ($repo in $repos) {
             # When running in GitHub Actions we will need to ensure the GitHub App is
             # authenticated for the current GitHub Org


### PR DESCRIPTION
Also:

- Updates `deploy_pr_autoflow` to configure repos for `delete_branch_on_merge`
- Adds `SpecFlow.NUnit.Runners` to the list of packages superceded by the meta package
- Fixes issue were `pr-autoflow` config file would keep getting updated due to non-ordered nature of hashtable
- Improves robustness of the git integration in `Update-Repo` when branches already exist