### PR TITLE
Enable remaining projects to use the SpecFlow meta package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install GitVersion
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"    
+        echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
         
     - name: Run GitVersion
       id: run_gitversion

--- a/.github/workflows/deploy_pr_autoflow.yml
+++ b/.github/workflows/deploy_pr_autoflow.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install GitVersion
         run: |
           dotnet tool install -g GitVersion.Tool --version 5.2.4
-          echo "::add-path::/github/home/.dotnet/tools"    
+          echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
       - name: Run GitVersion
         id: run_gitversion
         run: |

--- a/.github/workflows/sync_workflow_templates.yml
+++ b/.github/workflows/sync_workflow_templates.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install GitVersion
         run: |
           dotnet tool install -g GitVersion.Tool --version 5.2.4
-          echo "::add-path::/github/home/.dotnet/tools"    
+          echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
       - name: Run GitVersion
         id: run_gitversion
         run: |

--- a/repos/live/ais-dotnet.yml
+++ b/repos/live/ais-dotnet.yml
@@ -22,5 +22,5 @@ repos:
       AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS:
       - Corvus.*
     specflowMetaPackageSettings:
-      enabled: false
+      enabled: true
     syncWorkflowTemplates: false

--- a/repos/live/corvus-dotnet.yml
+++ b/repos/live/corvus-dotnet.yml
@@ -13,8 +13,20 @@ repos:
     name:
     - Corvus.AzureFunctionsKeepAlive
     - Corvus.Configuration
+    - Corvus.ContentHandling
+    - Corvus.Deployment
+    - Corvus.DotLiquidAsync
+    - Corvus.EventStore
     - Corvus.Extensions
+    - Corvus.Extensions.CommandLine
+    - Corvus.Extensions.CosmosDb
     - Corvus.Extensions.Newtonsoft.Json
+    - Corvus.Extensions.System.Text.Json
+    - Corvus.Identity
+    - Corvus.Leasing
+    - Corvus.Monitoring
+    - Corvus.Retry
+    - Corvus.Tenancy
     githubSettings:
       delete_branch_on_merge: false
     prAutoflowSettings:
@@ -25,32 +37,6 @@ repos:
       - Corvus.*
     specflowMetaPackageSettings:
       enabled: true
-    syncWorkflowTemplates: false
-
-  # repos enabled for PR-AUTOFLOW, but not SpecFlow meta package
-  - org: corvus-dotnet
-    name:
-    # - Corvus.ContentHandling
-    # - Corvus.DotLiquidAsync
-    - Corvus.EventStore
-    # - Corvus.Extensions.CommandLine
-    - Corvus.Extensions.CosmosDb
-    - Corvus.Extensions.System.Text.Json
-    - Corvus.Identity
-    - Corvus.Leasing
-    - Corvus.Monitoring
-    - Corvus.Retry
-    - Corvus.Tenancy    
-    githubSettings:
-      delete_branch_on_merge: false
-    prAutoflowSettings:
-      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - Endjin.*
-      - Corvus.*
-      AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - Corvus.*
-    specflowMetaPackageSettings:
-      enabled: false
     syncWorkflowTemplates: false
 
   # Corvus.Testing has custom PR-AUTOFLOW: auto-merges changes to SpecFlow packages

--- a/repos/live/endjin.yml
+++ b/repos/live/endjin.yml
@@ -3,6 +3,7 @@ repos:
     name:
     - Endjin.GitHubActions.PowerShell 
     - Endjin.CodeOps.PowerShell
+    - modern-data-platform
     githubSettings:
       delete_branch_on_merge: true
     prAutoflowSettings:

--- a/repos/live/marain-dotnet.yml
+++ b/repos/live/marain-dotnet.yml
@@ -12,7 +12,7 @@ repos:
     name:
     - Marain.Claims
     - Marain.ContentManagement
-    # - Marain.KeyRotation   # temporarily disabled due to default branch not being 'master'
+    - Marain.KeyRotation
     - Marain.Instance
     - Marain.Operations
     - Marain.Tenancy
@@ -30,5 +30,5 @@ repos:
       - Corvus.*
       - Menes.*
     specflowMetaPackageSettings:
-      enabled: false
+      enabled: true
     syncWorkflowTemplates: false

--- a/workflow-templates/auto_release.yml
+++ b/workflow-templates/auto_release.yml
@@ -120,7 +120,7 @@ jobs:
     - name: Install GitVersion
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"    
+        echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
     - name: Run GitVersion
       id: run_gitversion
       run: |

--- a/workflow-templates/manual_release.yml
+++ b/workflow-templates/manual_release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install GitVersion
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"    
+        echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
     - name: Run GitVersion
       id: run_gitversion
       run: |

--- a/workflow-templates/publish_to_dockerhub.yml
+++ b/workflow-templates/publish_to_dockerhub.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install GitVersion
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"    
+        echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
     - name: Run GitVersion
       id: run_gitversion
       run: |

--- a/workflow-templates/publish_to_psgallery.yml
+++ b/workflow-templates/publish_to_psgallery.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install GitVersion
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"    
+        echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
     - name: Run GitVersion
       id: run_gitversion
       run: |


### PR DESCRIPTION
Also fixes the use of the insecure `::set-path::` workflow command in this repo's workflows and the workflow templates.