### PR TITLE
Updates 'auto_release' workflow

### DIFF
--- a/workflow-templates/auto_release.yml
+++ b/workflow-templates/auto_release.yml
@@ -4,6 +4,45 @@ on:
     types: [closed]
 
 jobs:
+  lookup_default_branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.lookup_default_branch.outputs.result }}
+      head_commit: ${{ steps.lookup_default_branch_head.outputs.result }}
+    steps:
+    - name: Lookup default branch name
+      id: lookup_default_branch
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        result-encoding: string
+        script: |
+          const repo = await github.repos.get({
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name
+          });
+          return repo.data.default_branch
+    - name: Display default_branch_name
+      run: |
+        echo "default_branch_name : ${{ steps.lookup_default_branch.outputs.result }}"
+
+    - name: Lookup HEAD commit on default branch
+      id: lookup_default_branch_head
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        result-encoding: string
+        script: |
+          const branch = await github.repos.getBranch({
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name,
+            branch: '${{ steps.lookup_default_branch.outputs.result }}'
+          });
+          return branch.data.commit.sha
+    - name: Display default_branch_name_head
+      run: |
+        echo "default_branch_head_commit : ${{ steps.lookup_default_branch_head.outputs.result }}"
+        
   check_for_norelease_label:
     runs-on: ubuntu-latest
     outputs:
@@ -32,7 +71,7 @@ jobs:
 
   check_ready_to_release:
     runs-on: ubuntu-latest
-    needs: check_for_norelease_label
+    needs: [check_for_norelease_label,lookup_default_branch]
     if: |
       needs.check_for_norelease_label.outputs.no_release == 'false'
     outputs:
@@ -45,12 +84,16 @@ jobs:
       uses: actions/github-script@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        # find all open PRs that are targetting the default branch (i.e. main/master)
+        # return their titles, so they can parsed later to determine if they are
+        # Dependabot PRs and whether we should wait for them to be auto-merged before
+        # allowing a release event.
         script: |
           const pulls = await github.pulls.list({
             owner: context.payload.repository.owner.login,
             repo: context.payload.repository.name,
             state: 'open',
-            base: 'master'
+            base: '${{ needs.lookup_default_branch.outputs.branch_name }}'
           });
           return JSON.stringify(pulls.data.map(p=>p.title))
         result-encoding: string
@@ -105,7 +148,7 @@ jobs:
 
   tag_for_release:
     runs-on: ubuntu-latest
-    needs: check_ready_to_release
+    needs: [check_ready_to_release,lookup_default_branch]
     if: |
       needs.check_ready_to_release.outputs.ready_to_release == 'true'
     steps:
@@ -115,6 +158,8 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
+        # ensure we are creating the release tag on the default branch
+        ref: ${{ needs.lookup_default_branch.outputs.branch_name }}
         fetch-depth: 0
 
     - name: Install GitVersion
@@ -135,10 +180,17 @@ jobs:
         private_key: ${{ secrets.ENDJIN_BOT_PRIVATE_KEY }}
 
     - name: Create SemVer tag
-      uses: hole19/git-tag-action@master
-      env:
-        TAG: ${{ steps.run_gitversion.outputs.MajorMinorPatch }}
-        GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const uri_path = '/repos/' + context.payload.repository.owner.login + '/' + context.payload.repository.name + '/git/refs'
+          const tag = await github.request(('POST ' + uri_path), {
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name,
+            ref: 'refs/tags/${{ steps.run_gitversion.outputs.MajorMinorPatch }}',
+            sha: '${{ needs.lookup_default_branch.outputs.head_commit }}'
+          })
 
     - name: Remove 'release_pending' label from PRs
       id: remove_pending_release_labels


### PR DESCRIPTION
The `tag_for_release` job now explicitly tags the default branch for the repo.

This resolves the issue whereby PRs that were closed without merging could sometimes trigger a release event and their temporary PR branch would be the tagged reference.

Extra steps are now required to lookup the default branch and its latest commit SHA.

Also swaps the action used to create the tag to one that can support specifying the commit to be tagged.