### PR TITLE
Fixed identity used when tagging in 'auto_release' workflow

### DIFF
--- a/workflow-templates/auto_release.yml
+++ b/workflow-templates/auto_release.yml
@@ -182,7 +182,7 @@ jobs:
     - name: Create SemVer tag
       uses: actions/github-script@v2
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ steps.generate_token.outputs.token }}
         script: |
           const uri_path = '/repos/' + context.payload.repository.owner.login + '/' + context.payload.repository.name + '/git/refs'
           const tag = await github.request(('POST ' + uri_path), {


### PR DESCRIPTION
Use bot identity for tag operation so it can trigger other workflows.

This got inadvertently regressed when the tagging mechanism was changed in a previous update.