### PR TITLE
Update pr-autoflow configuration

### DIFF
--- a/repos/live/ais-dotnet.yml
+++ b/repos/live/ais-dotnet.yml
@@ -1,16 +1,6 @@
 repos:
   - org: ais-dotnet
     name:
-    - .github
-    prAutoflowSettings:
-      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - GitHub.Workflow.Templates
-    specflowMetaPackageSettings:
-      enabled: false
-    syncWorkflowTemplates: true
-    
-  - org: ais-dotnet
-    name:
     - Ais.Net
     - Ais.Net.Receiver
     - Ais.Net.Converters
@@ -19,7 +9,18 @@ repos:
       - Endjin.*
       - Corvus.*
       AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS:
-      - Corvus.*
-    specflowMetaPackageSettings:
-      enabled: true
-    syncWorkflowTemplates: false
+      - Corvus.AzureFunctionsKeepAlive
+      - Corvus.Configuration
+      - Corvus.ContentHandling
+      - Corvus.Deployment
+      - Corvus.DotLiquidAsync
+      - Corvus.EventStore
+      - Corvus.Extensions
+      - Corvus.Extensions.CosmosDb
+      - Corvus.Extensions.Newtonsoft.Json
+      - Corvus.Extensions.System.Text.Json
+      - Corvus.Identity
+      - Corvus.Leasing
+      - Corvus.Monitoring
+      - Corvus.Retry
+      - Corvus.Tenancy

--- a/repos/live/argotic.yml
+++ b/repos/live/argotic.yml
@@ -1,0 +1,8 @@
+repos:
+  - org: argotic-syndication-framework
+    name:
+    - Argotic
+    prAutoflowSettings:
+      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
+      - Endjin.*
+      AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: []

--- a/repos/live/corvus-dotnet.yml
+++ b/repos/live/corvus-dotnet.yml
@@ -1,15 +1,6 @@
 repos:
-  - org: corvus-dotnet
-    name:
-    - .github
-    prAutoflowSettings:
-      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - GitHub.Workflow.Templates
-    specflowMetaPackageSettings:
-      enabled: false
-    syncWorkflowTemplates: true
 
-  # repos enabled for PR-AUTOFLOW and SpecFlow meta package
+  # repos enabled for PR-AUTOFLOW
   - org: corvus-dotnet
     name:
     - Corvus.AzureFunctionsKeepAlive
@@ -28,26 +19,25 @@ repos:
     - Corvus.Monitoring
     - Corvus.Retry
     - Corvus.Tenancy
+    - Corvus.Testing
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
       - Corvus.*
+      # All repos except Corvus.Testing, which shouldn't trigger releases
       AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - Corvus.*
-    specflowMetaPackageSettings:
-      enabled: true
-    syncWorkflowTemplates: false
-
-  # Corvus.Testing has custom PR-AUTOFLOW: auto-merges changes to SpecFlow packages
-  - org: corvus-dotnet
-    name: Corvus.Testing
-    prAutoflowSettings:
-      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - Endjin.*
-      - Corvus.*
-      - SpecFlow.*
-      AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - Corvus.*
-    specflowMetaPackageSettings:
-      enabled: true
-    syncWorkflowTemplates: false
+      - Corvus.AzureFunctionsKeepAlive
+      - Corvus.Configuration
+      - Corvus.ContentHandling
+      - Corvus.Deployment
+      - Corvus.DotLiquidAsync
+      - Corvus.EventStore
+      - Corvus.Extensions
+      - Corvus.Extensions.CosmosDb
+      - Corvus.Extensions.Newtonsoft.Json
+      - Corvus.Extensions.System.Text.Json
+      - Corvus.Identity
+      - Corvus.Leasing
+      - Corvus.Monitoring
+      - Corvus.Retry
+      - Corvus.Tenancy

--- a/repos/live/marain-dotnet.yml
+++ b/repos/live/marain-dotnet.yml
@@ -1,16 +1,6 @@
 repos:
   - org: marain-dotnet
     name:
-    - .github
-    prAutoflowSettings:
-      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - GitHub.Workflow.Templates
-    specflowMetaPackageSettings:
-      enabled: false
-    syncWorkflowTemplates: true
-
-  - org: marain-dotnet
-    name:
     - Marain.Claims
     - Marain.ContentManagement
     - Marain.KeyRotation
@@ -26,8 +16,19 @@ repos:
       - Corvus.*
       - Menes.*
       AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - Corvus.*
+      - Corvus.AzureFunctionsKeepAlive
+      - Corvus.Configuration
+      - Corvus.ContentHandling
+      - Corvus.Deployment
+      - Corvus.DotLiquidAsync
+      - Corvus.EventStore
+      - Corvus.Extensions
+      - Corvus.Extensions.CosmosDb
+      - Corvus.Extensions.Newtonsoft.Json
+      - Corvus.Extensions.System.Text.Json
+      - Corvus.Identity
+      - Corvus.Leasing
+      - Corvus.Monitoring
+      - Corvus.Retry
+      - Corvus.Tenancy
       - Menes.*
-    specflowMetaPackageSettings:
-      enabled: true
-    syncWorkflowTemplates: false

--- a/repos/live/menes-dotnet.yml
+++ b/repos/live/menes-dotnet.yml
@@ -1,23 +1,24 @@
 repos:
   - org: menes-dotnet
     name:
-    - .github
-    prAutoflowSettings:
-      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - GitHub.Workflow.Templates
-    specflowMetaPackageSettings:
-      enabled: false
-    syncWorkflowTemplates: true
-    
-  - org: menes-dotnet
-    name:
     - Menes
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
       - Corvus.*
       AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS:
-      - Corvus.*
-    specflowMetaPackageSettings:
-      enabled: true
-    syncWorkflowTemplates: false
+      - Corvus.AzureFunctionsKeepAlive
+      - Corvus.Configuration
+      - Corvus.ContentHandling
+      - Corvus.Deployment
+      - Corvus.DotLiquidAsync
+      - Corvus.EventStore
+      - Corvus.Extensions
+      - Corvus.Extensions.CosmosDb
+      - Corvus.Extensions.Newtonsoft.Json
+      - Corvus.Extensions.System.Text.Json
+      - Corvus.Identity
+      - Corvus.Leasing
+      - Corvus.Monitoring
+      - Corvus.Retry
+      - Corvus.Tenancy

--- a/repos/live/vellum-dotnet.yml
+++ b/repos/live/vellum-dotnet.yml
@@ -1,22 +1,9 @@
 repos:
   - org: vellum-dotnet
     name:
-    - .github
-    prAutoflowSettings:
-      AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
-      - GitHub.Workflow.Templates
-    specflowMetaPackageSettings:
-      enabled: false
-    syncWorkflowTemplates: true
-
-  - org: vellum-dotnet
-    name:
     - vellum-cli
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
       - Corvus.*
       AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS: []
-    specflowMetaPackageSettings:
-      enabled: true
-    syncWorkflowTemplates: false


### PR DESCRIPTION
Prevent auto-release when updating corvus.testing
Remove redundant .github repos
Remove specflow migration config now all repos are migrated
Workflow sync now redundant too