### PR TITLE
Updates logic for deriving 'next-version' in GitVersion.yml

### DIFF
--- a/codeops-scripts/sync-pr-autoflow-to-repos.ps1
+++ b/codeops-scripts/sync-pr-autoflow-to-repos.ps1
@@ -66,7 +66,11 @@ function _repoChanges($OrgName, $RepoName)
                 $Null
             }
         } | Where-Object {
-            ($_ -ne $Null) -and (!$_.PreReleaseLabel)
+            # Builds of 'main' will produce a 'preview' pre-release version by default - only tagged versions
+            # produce stable version numbers.
+            # However, the 'next-version' value should reflect the current version number of the 'main' branch,
+            # so we should not ignore 'preview' pre-release tags.
+            ($_ -ne $Null) -and (!$_.PreReleaseLabel -or $_.PreReleaseLabel.StartsWith("preview.") )
         }
 
         if ($semVers) {


### PR DESCRIPTION
Resolves the issue recently seen with the [`Ais.Net.Receiver`](https://github.com/ais-dotnet/Ais.Net.Receiver/pull/150/files#diff-1b800222c322c27580a65856212fc4fd9bf1128603cb0864b2e85f6f22b567c9) repo, whereby `pr-autoflow` incorrectly changed the `next-version` value in the `GitVersion.yml` configuration file to an earlier version.

This changes the logic to reflect that `preview` pre-release tags represent versions that have been merged to `main` and should be treated as valid candidates when trying to identify the latest release.