### PR TITLE
Update GitHub Action workflows to not install the GitHub CLI

### DIFF
--- a/.github/workflows/deploy_pr_autoflow.yml
+++ b/.github/workflows/deploy_pr_autoflow.yml
@@ -32,13 +32,6 @@ jobs:
           pwsh -noprofile -c 'dotnet-gitversion /diag'
           pwsh -noprofile -c '(dotnet-gitversion | ConvertFrom-Json).psobject.properties | % { echo ("::set-output name={0}::{1}" -f $_.name, $_.value) }'
       
-      - name: Install GH CLI
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository -u https://cli.github.com/packages
-          sudo apt install gh
-        shell: bash
-      
       - name: Run sync-pr-autoflow-to-repos.ps1
         run: |
           Install-Module powershell-yaml -Force -Scope CurrentUser -Repository PSGallery

--- a/.github/workflows/migrate_to_specflow_meta_package.yml
+++ b/.github/workflows/migrate_to_specflow_meta_package.yml
@@ -14,12 +14,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install GH CLI
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository -u https://cli.github.com/packages
-          sudo apt install gh
-        shell: bash
       - name: Run migrate-to-specflow-meta-package.ps1
         run: |
           Install-Module powershell-yaml -Force -Scope CurrentUser -Repository PSGallery

--- a/.github/workflows/sync_workflow_templates.yml
+++ b/.github/workflows/sync_workflow_templates.yml
@@ -32,13 +32,6 @@ jobs:
           pwsh -noprofile -c 'dotnet-gitversion /diag'
           pwsh -noprofile -c '(dotnet-gitversion | ConvertFrom-Json).psobject.properties | % { echo ("::set-output name={0}::{1}" -f $_.name, $_.value) }'
 
-      - name: Install GH CLI
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository -u https://cli.github.com/packages
-          sudo apt install gh
-        shell: bash
-      
       - name: Run sync-workflow-templates.ps1
         run: |
           Install-Module powershell-yaml -Force -Scope CurrentUser -Repository PSGallery


### PR DESCRIPTION
It is now preinstalled on their agents and the process we were using no longer works due to changed public keys.