### PR TITLE
Add `contents: read` permission to `approve_and_label` workflow

### DIFF
--- a/workflow-templates/dependabot_approve_and_label.yml
+++ b/workflow-templates/dependabot_approve_and_label.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, reopened]
     
 permissions:
+  contents: read
   issues: write
   pull-requests: write
     


### PR DESCRIPTION
This is required for private repos to checkout itself in the `approve_and_label` workflow.

We did not notice before because it was not an issue for public repos.