### PR TITLE
Enroll new repos with 'pr-autoflow'

### DIFF
--- a/repos/live/corvus-dotnet.yml
+++ b/repos/live/corvus-dotnet.yml
@@ -24,6 +24,7 @@ repos:
     - Corvus.Tenancy
     - Corvus.Testing
     - Corvus.UriTemplates
+    - Corvus.Globbing
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS: 
       - Endjin.*
@@ -33,7 +34,6 @@ repos:
       - Corvus.AzureFunctionsKeepAlive
       - Corvus.Configuration
       - Corvus.ContentHandling
-      - Corvus.Deployment
       - Corvus.DotLiquidAsync
       - Corvus.EventStore
       - Corvus.Extensions
@@ -47,3 +47,5 @@ repos:
       - Corvus.Retry
       - Corvus.Storage
       - Corvus.Tenancy
+      - Corvus.UriTemplates
+      - Corvus.Globbing

--- a/repos/live/endjin.yml
+++ b/repos/live/endjin.yml
@@ -11,6 +11,7 @@ repos:
     - Endjin.Mdp.Bicep
     - Endjin.RecommendedPractices.Bicep
     - Endjin.RecommendedPractices.Build
+    - Endjin.BuildPlayground
     prAutoflowSettings:
       AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS:
       - Endjin.*


### PR DESCRIPTION
* Corvus.Globbing
* Endjin.BuildPlayground

Also removes `Corvus.Deployment` from the auto-merge list as this is not a NuGet dependency (it's a PowerShell module).