### PR TITLE
Fix condition bugs preventing `tag_for_release` ever running

### DIFF
--- a/workflow-templates/auto_release.yml
+++ b/workflow-templates/auto_release.yml
@@ -160,7 +160,7 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          return ( '${{ steps.is_human_pr.outputs.result }}' == 'True' || '${{ steps.watch_dependabot_prs.outputs.is_complete }}' == 'True') && '${{ steps.get_release_pending_pr_list.outputs.is_release_pending }}' == 'True'
+          return ( '${{ steps.is_human_pr.outputs.result }}' == 'true' || '${{ steps.watch_dependabot_prs.outputs.is_complete }}' == 'True') && '${{ steps.get_release_pending_pr_list.outputs.is_release_pending }}' == 'true'
 
     - name: Display job outputs
       run: |


### PR DESCRIPTION
The conditions being checked originate from a mix of PowerShell-based actions and inline GitHub scripts, each returning Booleans in a different format.

GitHub Actions is [case-insensitive when comparing strings](https://docs.github.com/en/actions/learn-github-actions/expressions#operators), but in the case of the conditions originating from GitHub scripts it seems likely that this is not a normal string comparison, as the scripts would be returning native Boolean values.